### PR TITLE
Fix handeDimesnsionsChange listener

### DIFF
--- a/use-dimensions.ts
+++ b/use-dimensions.ts
@@ -28,7 +28,7 @@ const getDimensions = (type: Type, getDimensions: Getter): Dimensions => {
     (): Unsubscribe => {
 
       // Event listener for when the dimensions change.
-      const handleDimensionsChange = (window: Dimensions, screen: Dimensions): void => {
+      const handleDimensionsChange = ({window, screen}: BothDimensions): void => {
         const newDimensions: Dimensions = getDimensions(window, screen);
         if (
           dimensions.height !== newDimensions.height ||


### PR DESCRIPTION
The event handler returns an object with window and screen properties [(docs)](https://facebook.github.io/react-native/docs/dimensions.html). Made the change to reflect this as the handler was returning undefined.