### PR TITLE
Prevent stale value of dimensions in handleDimensionsChange

### DIFF
--- a/use-dimensions.ts
+++ b/use-dimensions.ts
@@ -44,7 +44,7 @@ const getDimensions = (type: Type, getDimensions: Getter): Dimensions => {
         RNDimensions.removeEventListener('change', handleDimensionsChange);
       };
     },
-    [ RNDimensions ]
+    [ RNDimensions, dimensions ]
   );
   return dimensions;
 };


### PR DESCRIPTION
Since the useEffect hook does not include dimensions as a dependency, the reference to dimensions on lines 34/35 will always refer to the initial value. For correct behavior, it should refer to the most up to date value.

This causes a bug if you rotate a device to landscape and then back to portrait. The dimensions won't update on the rotation back to portrait